### PR TITLE
Escape `script` tag in code block

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,7 +23,7 @@
 		target = event.detail.target;
 	}
 
-	let code1 = `<scriptTag lang='ts'> // I could not close "script" tag in markdown for svelte reasons. Remember to rename it.
+	let code1 = `<script lang='ts'>
     import TransferList from '$lib/components/ui/transfer-list/transfer-list.svelte';
     
     // in current version shape of source object should be { id: number; name: string }, you can change it for your needs in the component
@@ -40,7 +40,7 @@
         source = event.detail.source;
         target = event.detail.target;
     }
-</scriptTag> 
+<\/script> 
 
 <TransferList
     bind:source


### PR DESCRIPTION
Hi there – I'm the maintainer of [svelte-highlight](https://github.com/metonym/svelte-highlight)

To fix the `script` parsing issue, the closing `</script>` tag in the template literal should be escaped for Svelte to parse it correctly.

<img width="1066" alt="escaped script tag" src="https://github.com/user-attachments/assets/5401b048-4cf0-487f-9dcb-3253da16345f">
